### PR TITLE
adjust height based on #entries shown

### DIFF
--- a/bash/html/CSS/custom.css
+++ b/bash/html/CSS/custom.css
@@ -58,5 +58,12 @@ THEAD, TFOOT { background-color:#FFF; background-image:none;   }
 	padding: 3px;
 	letter-spacing:2px;
 }
-	
+
+.dataTables_scrollBody[style] {
+    height: 100%!important;
+}
+
+#tabs {
+    overflow: auto;
+}
 	


### PR DESCRIPTION
overrides the 350px height, sets the tabs and the datatables to adjust themselves based on the number of results